### PR TITLE
:sparkles: Rebuilt log deletion confirmation dialog using Bootstrap. …

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,24 @@
             <textarea class="form-control" placeholder=""></textarea>
         </div>
     </div>
+
+    <!-- 削除確認モーダル -->
+    <div class="modal fade" id="deleteConfirmModal" tabindex="-1" aria-labelledby="deleteConfirmModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="deleteConfirmModalLabel" data-translate="delete_log_confirm_title"></h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body" data-translate="delete_log_confirm_message">
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" data-translate="cancel"></button>
+                    <button type="button" class="btn btn-danger" id="confirmDeleteButton" data-translate="delete"></button>
+                </div>
+            </div>
+        </div>
+    </div>
 </body>
 
 </html>

--- a/js/lib/multilingualization.js
+++ b/js/lib/multilingualization.js
@@ -51,6 +51,10 @@ export default class Multilingualization {
             "delete_log": "Delete log",
             "delete_log_confirm": "Are you sure you want to delete the log?",
             "install_pwa": "Install PWA",
+            "delete_log_confirm_title": "Delete log",
+            "delete_log_confirm_message": "Are you sure you want to delete the log?",
+            "cancel": "Cancel",
+            "delete": "Delete",  
         },
         "ja": {
             "app_name": "Fast logbook PWA",
@@ -95,6 +99,10 @@ export default class Multilingualization {
             "delete_log": "ログ削除",
             "delete_log_confirm": "本当にログを削除しますか？",
             "install_pwa": "PWAをインストール",
+            "delete_log_confirm_title": "ログ削除",
+            "delete_log_confirm_message": "本当にログを削除しますか？",
+            "cancel": "キャンセル",
+            "delete": "削除",  
         }
     }
 

--- a/js/main.js
+++ b/js/main.js
@@ -210,13 +210,26 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     // When delete_log link is pressed, delete the log
     $$one('a#delete_log').addEventListener('click', async () => {
-        if (confirm(Multilingualization.translate('delete_log_confirm'))) {
-            $$one('textarea').value = '';
-            await saveLogs();
+        // 削除確認モーダルを表示
+        const deleteConfirmModal = new bootstrap.Modal($$one('#deleteConfirmModal'));
+        deleteConfirmModal.show();
+    });
 
-            // Toggle visibility of navbar content
-            $$one('.navbar-toggler').click();
-        }
+    $$one('#confirmDeleteButton').addEventListener('click', async () => {
+        const textarea = $$one('textarea');
+        textarea.value = '';
+        await saveLogs();
+
+        // モーダルを閉じる
+        const deleteConfirmModal = bootstrap.Modal.getInstance($$one('#deleteConfirmModal'));
+        deleteConfirmModal.hide();
+
+        // ナビゲーションバーのコンテンツの表示を切り替える
+        $$one('.navbar-toggler').click();
+
+        setTimeout(() => {
+            textarea.focus();
+        }, 500);
     });
 
     // Register service worker

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Fast logbook PWA",
     "short_name": "Fast logbook",
-    "version": "24.08.01",
+    "version": "24.08.02",
     "description": "Time-stamped work notes PWA",
     "start_url": "/index.html",
     "display": "standalone",


### PR DESCRIPTION
# Add Confirmation Dialog for Log Deletion

This pull request adds a feature to display a confirmation dialog when deleting logs.

**Main changes:**

- Display a confirmation dialog when the log deletion button is clicked
- Delete the log only if the user selects "Yes"
- Add translation keys for multilingual support

**Expected effects:**

- Addresses the issue where the confirmation dialog was not displayed in the MS Edge sidebar, preventing log deletion.

**Test points:**

- Display of the confirmation dialog
- Log deletion behavior when "Yes" is selected
- Cancellation behavior when "No" is selected
- Verification of functionality in multilingual environments

This improvement is expected to enhance the usability and reliability of the application.