### PR TITLE
Modernize CI and add Claude Code project rules

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v5
-      - uses: flatt-security/setup-takumi-guard-npm@latest
+      - uses: flatt-security/setup-takumi-guard-npm@v1
       - uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v5
-      - uses: flatt-security/setup-takumi-guard-npm
+      - uses: flatt-security/setup-takumi-guard-npm@latest
       - uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,22 +9,10 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v5
-      - uses: flatt-security/setup-takumi-guard-npm@v1
-      - uses: pnpm/action-setup@v4
+      - uses: flatt-security/setup-takumi-guard-npm
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "pnpm"
-      - run: pnpm install --frozen-lockfile
-
-  npm-advisory-audit:
-    runs-on: ubuntu-slim
-    steps:
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "pnpm"
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm audit --audit-level=high
+          cache: "npm"
+      - run: npm ci
+      - run: npm audit --audit-level=high

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,15 +9,22 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v5
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Security audit
-        run: npm audit --audit-level=high
+  npm-advisory-audit:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm audit --audit-level=high

--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # Fast Logbook PWA
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)&emsp;
-![PWA](https://img.shields.io/badge/PWA-Yes-4BC51D.svg)&emsp;
-![Lint](https://github.com/hidao80/Fast-logbook-PWA/actions/workflows/lint.yml/badge.svg)&emsp;
-![Audit](https://github.com/hidao80/Fast-logbook-PWA/actions/workflows/audit.yml/badge.svg)&emsp;
-[![Netlify Status](https://api.netlify.com/api/v1/badges/e764aaa6-ad23-4945-8b6e-17a802224243/deploy-status)](https://app.netlify.com/sites/fast-logbook/deploys)&emsp;
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+![PWA](https://img.shields.io/badge/PWA-Yes-4BC51D.svg)
+![Lint](https://github.com/hidao80/Fast-logbook-PWA/actions/workflows/lint.yml/badge.svg)
+![Audit](https://github.com/hidao80/Fast-logbook-PWA/actions/workflows/audit.yml/badge.svg)
+[![Security: Takumi Guard](https://img.shields.io/badge/Security-Takumi%20Guard-blue)](https://github.com/hidao80/mago-vsx/actions/workflows/npm-scan.yml)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/e764aaa6-ad23-4945-8b6e-17a802224243/deploy-status)](https://app.netlify.com/sites/fast-logbook/deploys)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/hidao80/Fast-logbook-PWA)
 
-![Accessibility](https://img.shields.io/badge/Accessibility-94-brightgreen?style=flat-square)&emsp;![Best_Practices](https://img.shields.io/badge/Best_Practices-100-brightgreen?style=flat-square)&emsp;![Performance](https://img.shields.io/badge/Performance-93-brightgreen?style=flat-square)&emsp;![SEO](https://img.shields.io/badge/SEO-90-brightgreen?style=flat-square)&emsp;<sub>Measured on Jan 17, 2026 by [Lighthouse-badges](https://github.com/hidao80/lighthouse-badges) — [Measure now!](https://pagespeed.web.dev/analysis?url=https://fast-logbook.netlify.app/)</sub>
+![Accessibility](https://img.shields.io/badge/Accessibility-94-brightgreen?style=flat-square)
+![Best_Practices](https://img.shields.io/badge/Best_Practices-100-brightgreen?style=flat-square)
+![Performance](https://img.shields.io/badge/Performance-93-brightgreen?style=flat-square)
+![SEO](https://img.shields.io/badge/SEO-90-brightgreen?style=flat-square)
+<sub>Measured on Jan 17, 2026 by [Lighthouse-badges](https://github.com/hidao80/lighthouse-badges) — [Measure now!](https://pagespeed.web.dev/analysis?url=https://fast-logbook.netlify.app/)</sub>
 
 **Record with one tap. Instantly tally. No installation required.**
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![PWA](https://img.shields.io/badge/PWA-Yes-4BC51D.svg)
 ![Lint](https://github.com/hidao80/Fast-logbook-PWA/actions/workflows/lint.yml/badge.svg)
 ![Audit](https://github.com/hidao80/Fast-logbook-PWA/actions/workflows/audit.yml/badge.svg)
-[![Security: Takumi Guard](https://img.shields.io/badge/Security-Takumi%20Guard-blue)](https://github.com/hidao80/mago-vsx/actions/workflows/npm-scan.yml)
+[![Security: Takumi Guard](https://img.shields.io/badge/Security-Takumi%20Guard-blue)](https://github.com/hidao80/Fast-logbook-PWA/actions/workflows/npm-scan.yml)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/e764aaa6-ad23-4945-8b6e-17a802224243/deploy-status)](https://app.netlify.com/sites/fast-logbook/deploys)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/hidao80/Fast-logbook-PWA)
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ Option settings are saved automatically.
 
 ## :handshake: Contributing
 
-Bug reports and pull requests are welcome.
+Bug reports and pull requests are welcome.  
+Please note that this project uses [Takumi Guard](https://github.com/flatt-security/setup-takumi-guard-npm) in CI workflows to scan dependencies for malware and ensure supply chain security. This scanning only applies to CI and does not affect your local development environment.
 
 ## :page_facing_up: License
 


### PR DESCRIPTION
## Summary

- Add `.claude/` project rules (`CLAUDE.md`, `rules/code-style.md`, `rules/security.md`) to version control; exclude only `histories/` and `settings.local.json`
- Add [Takumi Guard](https://github.com/flatt-security/setup-takumi-guard-npm) supply chain malware scan to the audit CI workflow
- Switch CI from Biome CLI step to `reviewdog-action-biome` for inline PR review comments
- Bump `actions/checkout` to v5 in all workflows; remove `pull_request` triggers (push-only)
- Clarify dev command (`npm run dev`) and localhost secure context behavior in docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Takumi Guard security badge to the project header for visible security status.
  * Clarified in Contributing that dependency malware scanning runs in CI workflows (not local development).
  * Cleaned up badge and metrics layout and spacing for improved readability; preserved existing performance/SEO/Lighthouse metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->